### PR TITLE
Adds support for selection of LaTeX compiler

### DIFF
--- a/ajax/compile.php
+++ b/ajax/compile.php
@@ -9,7 +9,15 @@ $l = OC_L10N::get('files_latexeditor');
 set_time_limit(0); //scanning can take ages
 
 $dir = isset($_POST['path']) ? $_POST['path'] : '';
-$pdflatex = isset($_POST['pdflatex']) ? (bool) $_POST['pdflatex'] : false;
+
+// Check if we've been given a compiler, otherwise use latex as default
+$compiler = isset($_POST['compiler']) ? $_POST['compiler'] : 'latex';
+// If they've set the compiler to something other than an allowable option....
+if( !($compiler === 'xelatex' || $compiler === 'pdflatex' || $compiler === 'latex')){
+	$compiler = 'latex';
+}
+
+#$pdflatex = isset($_POST['pdflatex']) ? (bool) $_POST['pdflatex'] : false;
 $file = isset($_POST['filename']) ? $_POST['filename'] : '';
 
 $userid = OCP\USER::getUser();
@@ -32,15 +40,18 @@ if(!\OC\Files\Filesystem::isCreatable(stripslashes($dir))) {
 
 $outpath = "/tmp/latex_" . $userid . "_" . $projectname;
 
-$mkdir_command = "mkdir -p  " . $outpath ;
+$copy_directory_tree_command = "rsync -av -f\"+ */\" -f\"- *\" $workdir/ $outpath";
 $cd_command = "cd " . str_replace(' ','\ ',trim($workdir)) ;
-if ($pdflatex === true)
-    $latex_command .= "pdflatex -output-directory $outpath $file";
-else
+
+if($compiler == 'xelatex' || $compiler == 'pdflatex'){
+    $latex_command .= $compiler . " -output-directory $outpath $file";
+}
+else{
     $latex_command .= "latex -output-directory=$outpath  $file ; cd $outpath; dvips  $dvifile ; ps2pdf $psfile";
+}
 $output = "========BEGIN COMPILE $psfile ======== \n "; // % $latex_command\n";
 
-$return = shell_exec($mkdir_command . " && " . $cd_command . " && " . $latex_command);
+$return = shell_exec($copy_directory_tree_command . " && " . $cd_command . " && " . $latex_command);
 $log = file_get_contents($outpath . '/' . $logfile);
 
 while (preg_match('/Rerun to get cross-references right/',$log) || preg_match('/No file '.$tocfile.'/',$log)){
@@ -77,7 +88,7 @@ $output .= "\n========END COMPILE==========\n";
 
 if(file_exists($workdir . '/' . $pdffile))
 	\OC\Files\Filesystem::unlink($workdir . '/' . $pdffile);
-if (!$pdflatex && file_exists($workdir . '/' . $psfile) )
+if ($compiler === 'latex' && file_exists($workdir . '/' . $psfile) )
 	\OC\Files\Filesystem::unlink($workdir . '/' . $psfile);
 
 if (!@rename(trim($outpath . '/' . $pdffile), trim($workdir . '/'. $pdffile))) {
@@ -87,7 +98,7 @@ if (!@rename(trim($outpath . '/' . $pdffile), trim($workdir . '/'. $pdffile))) {
     $output.="<strong>" . trim($outpath . '/' . $pdffile) . " to " . trim($workdir . '/' . $pdffile) . "</strong>";
 } else {
     $output.="<strong> Copy " . trim($outpath . '/' . $pdffile) . " to " . trim($workdir . '/' . $pdffile) . "</strong>";
-    if (!$pdflatex) {
+    if ($compiler === 'latex') {
         if (!@rename(trim($outpath . '/' . $psfile), trim($workdir . '/' . $psfile))) {
             $errors = error_get_last();
             $output.="\n>>>> " . $l->t("COPY ERROR: ") . $errors['type'];
@@ -101,7 +112,7 @@ $output.="\n>>>> " . $l->t("COPY DONE: ") . "\n";
 $target = OCP\Files::buildNotExistingFileName(stripslashes($workdir), $pdffile);
 $target = \OC\Files\Filesystem::normalizePath($target);
 $meta =  \OC\Files\Filesystem::getFileInfo($target);
-if (!$pdflatex) {
+if ($compiler === 'latex') {
     $target = OCP\Files::buildNotExistingFileName(stripslashes($workdir), $psfile);
     $target = \OC\Files\Filesystem::normalizePath($target);
     $meta =  \OC\Files\Filesystem::getFileInfo($target);

--- a/js/editor.js
+++ b/js/editor.js
@@ -383,7 +383,7 @@ function AjaxCompile(ajaxpath, path,filename,pdflatex){
         data: {
             path:path,
             filename:filename,
-            pdflatex:pdflatex?1:0
+            compiler:pdflatex
         },
         dataType: 'json',
         global: false,
@@ -432,7 +432,7 @@ function compileFile(filename,path){
         open: function(e, ui) {
             $(e.target).parent().find('span').filter(function(){
                 return $(this).text() === 'dummy';
-            }).parent().replaceWith('<input id="pdflatex" value="pdflatex" name="pdflatex" type=\'checkbox\'>use pdflatex </input>');
+            }).parent().replaceWith('<select id="compiler" name="compiler"><option value="latex">LaTeX</option><option value="pdflatex">PDFLaTeX</option><option value="xelatex">XeLaTeX</option></select>');
         },
         buttons: {
             'dummy': function(e){
@@ -440,7 +440,7 @@ function compileFile(filename,path){
             Compile: function(){
 
                 $('#latexresult').html("Compiling...");
-                json=AjaxCompile(ajaxpath,path, filename,$('#pdflatex').is(':checked'));
+                json=AjaxCompile(ajaxpath,path, filename,$('#compiler').val());
                 if(json){
                     //alert(json.data.output);
                     $('#latexresult').html("");


### PR DESCRIPTION
This commit adds support for selection of LaTeX compiler, between LaTeX, pdfLaTeX, and XeLaTeX. It should be relatively trivial to add more compilers. 

Additionally a small bug is fixed wherein a LaTeX project has multiple subdirectories where data is stored (e.g., `/images/`, `/chapters/`) and those directories must be created in the temporary compilation directory for compilation to succeed. This is done with the `$copy_directory_tree_command` variable, the command for which was pulled from http://www.cyberciti.biz/faq/unix-linux-bsdosx-copying-directory-structures-trees-rsync/
